### PR TITLE
sending sms with twilio from the server

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+ACCOUNT_SID=put the account id
+AUTH_TOKEN = your authToken

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+### Description
+
+### How to test
+
+
+### How has this been tested?
+
+- [ ]  Unit testing
+- [ ]  Integration testing
+- [ ]  End-to-end testing
+
+### Jira
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1939,6 +1939,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/core": "^7.12.3",
     "@babel/node": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "nodemon": "^2.0.6",
     "twilio": "^3.50.0"

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -1,7 +1,30 @@
+import 'dotenv/config';
+
+
+const accountSid = process.env.ACCOUNT_SID; 
+const authToken = process.env.AUTH_TOKEN; 
+const client = require('twilio')(accountSid, authToken);
+
+ 
 class sms {
     static async sms(req, res) {
+        try{
+        const {phone, message} = req.body;
 
-  console.log('hellooo///////')
+    client.messages 
+      .create({  
+         from: '+12013836815',       
+         to: phone,
+         body: message
+       }) 
+      .then(message => res.status(201).json({
+          status: 201,
+          message
+      })) 
+      .done();
+        }catch(err){
+            console.log('err from twilio', err);
+        }
 
     }
 }


### PR DESCRIPTION
### Description

This PR adds the functionality of sending an SMS from Twilio.

### How to test

1. clone the repo 
2. make sure you're inside the sms project
3. **run npm install**
4. user postman and create a POST request on http://localhost:5000/sms. 
The request body: `{
"phone": "phone to send sms to",
"message":"your message" 
}`



### How has this been tested?

- [ ]  Unit testing
- [ ]  Integration testing
- [ ]  End-to-end testing

